### PR TITLE
Ammend PS2 compilers

### DIFF
--- a/platforms/ps2/ee-gcc2.95.2-273a/Dockerfile
+++ b/platforms/ps2/ee-gcc2.95.2-273a/Dockerfile
@@ -3,16 +3,10 @@
 
 FROM alpine:3.18 as base
 
-# download xz first to allow for Docker caching
-
-WORKDIR /root
-
-RUN wget -O ps2_compilers.tar.xz "https://github.com/decompme/compilers/releases/download/compilers/ps2_compilers.tar.xz"
-RUN tar xvJf ps2_compilers.tar.xz
-
 RUN mkdir -p /compilers/ps2/ee-gcc2.95.2-273a
 
-RUN cp -r ee-gcc2.95.2-273a/* /compilers/ps2/ee-gcc2.95.2-273a
+RUN wget -O ee-gcc2.95.2-273a.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/ee-gcc2.95.2-273a.tar.gz"
+RUN tar xvzf ee-gcc2.95.2-273a.tar.gz -C /compilers/ps2/ee-gcc2.95.2-273a
 
 RUN chown -R root:root /compilers/ps2/ee-gcc2.95.2-273a/
 RUN chmod +x /compilers/ps2/ee-gcc2.95.2-273a/*

--- a/platforms/ps2/ee-gcc2.95.3-114/Dockerfile
+++ b/platforms/ps2/ee-gcc2.95.3-114/Dockerfile
@@ -3,16 +3,10 @@
 
 FROM alpine:3.18 as base
 
-# download xz first to allow for Docker caching
-
-WORKDIR /root
-
-RUN wget -O ps2_compilers.tar.xz "https://github.com/decompme/compilers/releases/download/compilers/ps2_compilers.tar.xz"
-RUN tar xvJf ps2_compilers.tar.xz
-
 RUN mkdir -p /compilers/ps2/ee-gcc2.95.3-114
 
-RUN cp -r ee-gcc2.95.3-114/* /compilers/ps2/ee-gcc2.95.3-114
+RUN wget -O ee-gcc2.95.3-114.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/ee-gcc2.95.3-114.tar.gz"
+RUN tar xvzf ee-gcc2.95.3-114.tar.gz -C /compilers/ps2/ee-gcc2.95.3-114
 
 RUN chown -R root:root /compilers/ps2/ee-gcc2.95.3-114/
 RUN chmod +x /compilers/ps2/ee-gcc2.95.3-114/*

--- a/platforms/ps2/ee-gcc2.95.3-136/Dockerfile
+++ b/platforms/ps2/ee-gcc2.95.3-136/Dockerfile
@@ -3,16 +3,10 @@
 
 FROM alpine:3.18 as base
 
-# download xz first to allow for Docker caching
-
-WORKDIR /root
-
-RUN wget -O ps2_compilers.tar.xz "https://github.com/decompme/compilers/releases/download/compilers/ps2_compilers.tar.xz"
-RUN tar xvJf ps2_compilers.tar.xz
-
 RUN mkdir -p /compilers/ps2/ee-gcc2.95.3-136
 
-RUN cp -r ee-gcc2.95.3-136/* /compilers/ps2/ee-gcc2.95.3-136
+RUN wget -O ee-gcc2.95.3-136.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/ee-gcc2.95.3-136.tar.gz"
+RUN tar xvzf ee-gcc2.95.3-136.tar.gz -C /compilers/ps2/ee-gcc2.95.3-136
 
 RUN chown -R root:root /compilers/ps2/ee-gcc2.95.3-136/
 RUN chmod +x /compilers/ps2/ee-gcc2.95.3-136/*

--- a/values.yaml
+++ b/values.yaml
@@ -343,8 +343,8 @@ compilers:
 
   - id: ee-gcc2.95.2-273a
     platform: ps2
-    template: common/xz
-    file: https://github.com/decompme/compilers/releases/download/compilers/ps2_compilers.tar.xz
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/ee-gcc2.95.2-273a.tar.gz
   - id: ee-gcc2.95.2-274
     platform: ps2
     template: common/xz
@@ -355,12 +355,12 @@ compilers:
     file: https://github.com/decompme/compilers/releases/download/compilers/ps2_compilers.tar.xz
   - id: ee-gcc2.95.3-114
     platform: ps2
-    template: common/xz
-    file: https://github.com/decompme/compilers/releases/download/compilers/ps2_compilers.tar.xz
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/ee-gcc2.95.3-114.tar.gz
   - id: ee-gcc2.95.3-136
     platform: ps2
-    template: common/xz
-    file: https://github.com/decompme/compilers/releases/download/compilers/ps2_compilers.tar.xz
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/ee-gcc2.95.3-136.tar.gz
   - id: mwcps2-2.3-991202
     platform: ps2
     template: common/xz


### PR DESCRIPTION
Ammends some of the compilers to add their alternative assembler, the referenced archives:
[ee-gcc2.95.2-273a.tar.gz](https://github.com/user-attachments/files/23760096/ee-gcc2.95.2-273a.tar.gz)
[ee-gcc2.95.3-114.tar.gz](https://github.com/user-attachments/files/23760097/ee-gcc2.95.3-114.tar.gz)
[ee-gcc2.95.3-136.tar.gz](https://github.com/user-attachments/files/23760098/ee-gcc2.95.3-136.tar.gz)
