### PR TITLE
Add rof2elf.py to Dreamcast downloads

### DIFF
--- a/platforms/dreamcast/shc-v5.0r10/Dockerfile
+++ b/platforms/dreamcast/shc-v5.0r10/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.0r10
 
 RUN wget -O shc-v5.0r10.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r10.tar.gz"
 RUN tar xvzf shc-v5.0r10.tar.gz -C /compilers/dreamcast/shc-v5.0r10
+RUN wget -O /compilers/dreamcast/shc-v5.0r10/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.0r10/
 RUN chmod +x /compilers/dreamcast/shc-v5.0r10/*

--- a/platforms/dreamcast/shc-v5.0r26/Dockerfile
+++ b/platforms/dreamcast/shc-v5.0r26/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.0r26
 
 RUN wget -O shc-v5.0r26.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r26.tar.gz"
 RUN tar xvzf shc-v5.0r26.tar.gz -C /compilers/dreamcast/shc-v5.0r26
+RUN wget -O /compilers/dreamcast/shc-v5.0r26/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.0r26/
 RUN chmod +x /compilers/dreamcast/shc-v5.0r26/*

--- a/platforms/dreamcast/shc-v5.0r28/Dockerfile
+++ b/platforms/dreamcast/shc-v5.0r28/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.0r28
 
 RUN wget -O shc-v5.0r28.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r28.tar.gz"
 RUN tar xvzf shc-v5.0r28.tar.gz -C /compilers/dreamcast/shc-v5.0r28
+RUN wget -O /compilers/dreamcast/shc-v5.0r28/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.0r28/
 RUN chmod +x /compilers/dreamcast/shc-v5.0r28/*

--- a/platforms/dreamcast/shc-v5.0r31/Dockerfile
+++ b/platforms/dreamcast/shc-v5.0r31/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.0r31
 
 RUN wget -O shc-v5.0r31.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r31.tar.gz"
 RUN tar xvzf shc-v5.0r31.tar.gz -C /compilers/dreamcast/shc-v5.0r31
+RUN wget -O /compilers/dreamcast/shc-v5.0r31/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.0r31/
 RUN chmod +x /compilers/dreamcast/shc-v5.0r31/*

--- a/platforms/dreamcast/shc-v5.0r32/Dockerfile
+++ b/platforms/dreamcast/shc-v5.0r32/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.0r32
 
 RUN wget -O shc-v5.0r32.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r32.tar.gz"
 RUN tar xvzf shc-v5.0r32.tar.gz -C /compilers/dreamcast/shc-v5.0r32
+RUN wget -O /compilers/dreamcast/shc-v5.0r32/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.0r32/
 RUN chmod +x /compilers/dreamcast/shc-v5.0r32/*

--- a/platforms/dreamcast/shc-v5.1r01/Dockerfile
+++ b/platforms/dreamcast/shc-v5.1r01/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.1r01
 
 RUN wget -O shc-v5.1r01.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r01.tar.gz"
 RUN tar xvzf shc-v5.1r01.tar.gz -C /compilers/dreamcast/shc-v5.1r01
+RUN wget -O /compilers/dreamcast/shc-v5.1r01/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.1r01/
 RUN chmod +x /compilers/dreamcast/shc-v5.1r01/*

--- a/platforms/dreamcast/shc-v5.1r03/Dockerfile
+++ b/platforms/dreamcast/shc-v5.1r03/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.1r03
 
 RUN wget -O shc-v5.1r03.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r03.tar.gz"
 RUN tar xvzf shc-v5.1r03.tar.gz -C /compilers/dreamcast/shc-v5.1r03
+RUN wget -O /compilers/dreamcast/shc-v5.1r03/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.1r03/
 RUN chmod +x /compilers/dreamcast/shc-v5.1r03/*

--- a/platforms/dreamcast/shc-v5.1r04/Dockerfile
+++ b/platforms/dreamcast/shc-v5.1r04/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.1r04
 
 RUN wget -O shc-v5.1r04.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r04.tar.gz"
 RUN tar xvzf shc-v5.1r04.tar.gz -C /compilers/dreamcast/shc-v5.1r04
+RUN wget -O /compilers/dreamcast/shc-v5.1r04/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.1r04/
 RUN chmod +x /compilers/dreamcast/shc-v5.1r04/*

--- a/platforms/dreamcast/shc-v5.1r08/Dockerfile
+++ b/platforms/dreamcast/shc-v5.1r08/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.1r08
 
 RUN wget -O shc-v5.1r08.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r08.tar.gz"
 RUN tar xvzf shc-v5.1r08.tar.gz -C /compilers/dreamcast/shc-v5.1r08
+RUN wget -O /compilers/dreamcast/shc-v5.1r08/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.1r08/
 RUN chmod +x /compilers/dreamcast/shc-v5.1r08/*

--- a/platforms/dreamcast/shc-v5.1r11/Dockerfile
+++ b/platforms/dreamcast/shc-v5.1r11/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.1r11
 
 RUN wget -O shc-v5.1r11.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r11.tar.gz"
 RUN tar xvzf shc-v5.1r11.tar.gz -C /compilers/dreamcast/shc-v5.1r11
+RUN wget -O /compilers/dreamcast/shc-v5.1r11/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.1r11/
 RUN chmod +x /compilers/dreamcast/shc-v5.1r11/*

--- a/platforms/dreamcast/shc-v5.1r13/Dockerfile
+++ b/platforms/dreamcast/shc-v5.1r13/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /compilers/dreamcast/shc-v5.1r13
 
 RUN wget -O shc-v5.1r13.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r13.tar.gz"
 RUN tar xvzf shc-v5.1r13.tar.gz -C /compilers/dreamcast/shc-v5.1r13
+RUN wget -O /compilers/dreamcast/shc-v5.1r13/rof2elf.py "https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py"
 
 RUN chown -R root:root /compilers/dreamcast/shc-v5.1r13/
 RUN chmod +x /compilers/dreamcast/shc-v5.1r13/*

--- a/values.yaml
+++ b/values.yaml
@@ -1083,47 +1083,69 @@ compilers:
   - id: shc-v5.0r10
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r10.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r10.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.0r26
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r26.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r26.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.0r28
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r28.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r28.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.0r31
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r31.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r31.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.0r32
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r32.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.0r32.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.1r01
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r01.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r01.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.1r03
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r03.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r03.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.1r04
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r04.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r04.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.1r08
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r08.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r08.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.1r11
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r11.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r11.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
   - id: shc-v5.1r13
     platform: dreamcast
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r13.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/shc-v5.1r13.tar.gz
+      - https://gist.githubusercontent.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a/raw/18fbf1a19bd720d02774ed634b00b0508eaf474c/rof2elf.py
 
   # Xbox 360
   - id: msvc_ppc_14.00.2110


### PR DESCRIPTION
Adds a self-made utility to the Dreamcast compilers that converts sysrof files to elf, unlike the provided ELFCNV.EXE that's bundled with the sdk the script can also convert line info, which is a nice bonus.
The script is pulled from this GitHub Gist https://gist.github.com/Mc-muffin/c2d3f30e50c5c5749f994973441c503a