### PR TITLE
Add agbcc FE8J compiler

### DIFF
--- a/platforms/gba/agbcc-fe8j/Dockerfile
+++ b/platforms/gba/agbcc-fe8j/Dockerfile
@@ -1,0 +1,17 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 AS base
+
+RUN mkdir -p /compilers/gba/agbcc-fe8j
+
+RUN wget -O agbcc.tar.gz "https://github.com/laqieer/agbcc/releases/download/fe8j-v1/agbcc.tar.gz"
+RUN tar xvzf agbcc.tar.gz -C /compilers/gba/agbcc-fe8j
+
+RUN chown -R root:root /compilers/gba/agbcc-fe8j/
+RUN chmod +x /compilers/gba/agbcc-fe8j/*
+
+
+FROM scratch AS release
+
+COPY --from=base /compilers /compilers

--- a/values.yaml
+++ b/values.yaml
@@ -561,6 +561,10 @@ compilers:
     platform: gba
     template: common/default
     file: https://github.com/pret/agbcc/releases/download/release/agbcc.tar.gz
+  - id: agbcc-fe8j
+    platform: gba
+    template: common/default
+    file: https://github.com/laqieer/agbcc/releases/download/fe8j-v1/agbcc.tar.gz
   - id: agbccpp
     platform: gba
     template: common/default


### PR DESCRIPTION
Adds the `agbcc-fe8j` compiler package for [fireemblem8j issue #168](https://github.com/laqieer/fireemblem8j/issues/168).

The artifact is built from [`pret/agbcc` `da598c1`](https://github.com/pret/agbcc/commit/da598c1d918402c42c0c0d7128ba14567f3175e9) plus the default-off FE8J target flags on [`laqieer/agbcc@fe8j`](https://github.com/laqieer/agbcc/tree/fe8j). The permanent release is [`fe8j-v1`](https://github.com/laqieer/agbcc/releases/tag/fe8j-v1).

`-mjp-promote` preserves signed sub-word promotion and enables declaration-order function-argument promotion. With no FE8J flag, validated `.text` output matches stock agbcc; with `-mjp-promote`, the known `AddGorgonEggTrap` case produces the required FE8J argument-extension order. The packaged release also completed a clean full fireemblem8j build with `fireemblem8.gba: OK`.

A follow-up decomp.me application PR will register this package and add a focused compile test for `-mjp-promote` once this image is published.